### PR TITLE
use absolute path for static serving

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -18,7 +18,7 @@ console.log("Started server");
 var aRouter = express();
 var myServer = http.createServer(aRouter);
 
-aRouter.use(express.static('public'));
+aRouter.use(express.static(__dirname+'/public'));
 
 aRouter.get('/location/:location', function(req,res){
     getLocation(req.params.location, function(result){


### PR DESCRIPTION
Anything that is linked has to use absolute pathing, since the app is running from a different directory now.
